### PR TITLE
Add release-drafter.yml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,18 @@
+# Release Drafter config yaml
+# https://github.com/marketplace/actions/release-drafter
+
+name-template: 'v$NEXT_MINOR_VERSION'
+tag-template: 'v$NEXT_MINOR_VERSION'
+change-title-escapes: '\<*_&'
+category-template: "### $TITLE"
+categories:
+  - title: 'Features'
+    labels: 'enhancement'
+  - title: 'Bug Fixes'
+    labels: 'bug'
+exclude-labels:
+  - 'not on release note'
+template: |
+  ## Changes
+
+  $CHANGES


### PR DESCRIPTION
I would like to add support for [release drafter](https://github.com/release-drafter/release-drafter) action to aapf organization. This release-drafter.yml is the setting yaml file for all repositories in the organizarion.

> Release Drafter also supports Probot Config, if you want to store your configuration files in a central repository. This allows you to share configurations between projects, and create a organization-wide configuration file by creating a repository named .github with the file .github/release-drafter.yml.




