### PR TITLE
Add support for EditorConfig & markdownlint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -3,29 +3,29 @@ name: Bug report
 about: Create a bug report to help us improve
 ---
 
-### Description:
+### Description
 
 Under the following conditions, OO cannot XX.
 
- * ...
- * ...
+* ...
+* ...
 
-### Steps to reproduce:
+### Steps to reproduce
 
 This issue can be reproduced by the steps below. The probability to reproduce this issue is OO%.
 
- * ...
- * ...
+* ...
+* ...
 
-### Expected behavior:
-
-...
-
-### Actual behavior:
+### Expected behavior
 
 ...
 
-### Environment configuration:
+### Actual behavior
+
+...
+
+### Environment configuration
 
 The environment information (OS, version, etc.)
 

--- a/.github/ISSUE_TEMPLATE/task_for_userstory.md
+++ b/.github/ISSUE_TEMPLATE/task_for_userstory.md
@@ -3,31 +3,31 @@ name: Task format for User Story (Japanese)
 about: Create a task for User Story
 ---
 
-### 作業内容:
+### 作業内容
 
 * ...
 * ...
 
-### 終了条件:
+### 終了条件
 
 * ...
 * ...
 
-### タスク:
+### タスク
 
 * ...
 * ...
 
-### 課題:
+### 課題
 
 * ...
 * ...
 
-### 関連ユーザーストーリー:
+### 関連ユーザーストーリー
 
 * <The link to UserStory>
 
-### 関連資料:
+### 関連資料
 
 * <The link to document>
 

--- a/.github/ISSUE_TEMPLATE/userstory.md
+++ b/.github/ISSUE_TEMPLATE/userstory.md
@@ -3,36 +3,36 @@ name: User Story format (Japanese)
 about: Create a User Story
 ---
 
-### 誰が何をできるようにするのか:
+### 誰が何をできるようにするのか
 
 * ...
 * ...
 
-### 背景:
+### 背景
 
 * ...
 * ...
 
-### 達成条件:
+### 達成条件
 
 * ...
 * ...
 
-### 課題:
+### 課題
 
 * ...
 * ...
 
-### リスク:
+### リスク
 
 * ...
 * ...
 
-### 関連タスク:
+### 関連タスク
 
 * <The link to Task for User Story>
 
-### 関連資料:
+### 関連資料
 
 * <The link to document>
 

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,0 +1,39 @@
+---
+###########################
+###########################
+## Markdown Linter rules ##
+###########################
+###########################
+
+# This file is based on:
+# - https://github.com/github/super-linter/blob/master/TEMPLATES/.markdown-lint.yml
+
+# Linter rules doc:
+# - https://github.com/DavidAnson/markdownlint
+#
+# Note:
+# To comment out a single error:
+#   <!-- markdownlint-disable -->
+#   any violations you want
+#   <!-- markdownlint-restore -->
+#
+
+###############
+# Rules by id #
+###############
+MD004: false                  # Unordered list style
+MD007:
+  indent: 2                   # Unordered list indentation
+MD013:
+  line_length: 400            # Line length 80 is far to short
+MD026:
+  punctuation: ".,;:!。，；:"  # List of not allowed
+MD029: false                  # Ordered list item prefix
+MD033: false                  # Allow inline HTML
+MD036: false                  # Emphasis used instead of a heading
+MD041: false                  # First line should be a top-level heading
+
+#################
+# Rules by tags #
+#################
+blank_lines: false  # Error on blank lines

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,20 @@
+name: Lint Code Base
+
+on: [push]
+
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+      - name: Lint Code Base
+        uses: github/super-linter@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_EDITORCONFIG: true
+          VALIDATE_MARKDOWN: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+super-linter.log


### PR DESCRIPTION
Add support for EditorConfig and [markdownlint](https://github.com/DavidAnson/markdownlint) ([aapf/enpro#26](https://github.com/aapf/enpro/issues/26))

Issue template は H3 から始めるため、MD041 (First line should be a top-level heading) を無効化しています。 